### PR TITLE
add:genarateコマンドでの生成ファイル制限 #11

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -24,6 +24,11 @@ module MajiInfo
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 6.1
 
+    config.generators do |g|
+      g.assets false
+      g.skip_routes true
+      g.helper false
+    end
     # Configuration for the application, engines, and railties goes here.
     #
     # These settings can be overridden in specific environments using the files


### PR DESCRIPTION
CSSファイル
ヘルパーファイル
ルーティング

が生成されないように制限しました。