### PR TITLE
#34 add columns to post table

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -44,6 +44,6 @@ class PostsController < ApplicationController
     end
 
     def post_params
-      params.require(:post).permit(:body)
+      params.require(:post).permit(:title, :body, :url, :contributor)
     end
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,5 @@
 class Post < ApplicationRecord
-  validates :body, presence: true
+  validates :url, presence: true, uniqueness: true
 
   scope :random, -> { offset(rand(Post.count)).first }
 end

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,8 @@
 class Post < ApplicationRecord
   validates :url, presence: true, uniqueness: true
+  validates :body, presence: true, uniqueness: true
+  validates :title, presence: true, uniqueness: true
+  validates :contributor, presence: true
 
   scope :random, -> { offset(rand(Post.count)).first }
 end

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -10,8 +10,20 @@
   <% end %>
 
   <div class="field">
+    <%= form.label :title %>
+    <%= form.text_field :title %>
+  </div>
+  <div class="field">
     <%= form.label :body %>
     <%= form.text_area :body %>
+  </div>
+  <div class="field">
+    <%= form.label :url %>
+    <%= form.url_field :url %>
+  </div>
+  <div class="field">
+    <%= form.label :contributor %>
+    <%= form.text_field :contributor %>
   </div>
 
   <div class="actions">

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -3,17 +3,23 @@
 <table>
   <thead>
     <tr>
-      <th><%= Post.human_attribute_name(:id) %></th>
+      <td></td>
+      <th><%= Post.human_attribute_name(:title) %></th>
       <th><%= Post.human_attribute_name(:body) %></th>
-      <th colspan="3"></th>
+      <th><%= Post.human_attribute_name(:url) %></th>
+      <th><%= Post.human_attribute_name(:contributor) %></th>
+      <th colspan="5"></th>
     </tr>
   </thead>
 
   <tbody>
-    <% @posts.each do |post| %>
+    <% @posts.each.with_index(1) do |post, index| %>
       <tr>
-        <td><%= post.id %></td>
+        <td><%= index %></td>
+        <td><%= post.title %></td>
         <td><%= post.body %></td>
+        <td><%= post.url %></td>
+        <td><%= post.contributor %></td>
         <td><%= link_to t("defaults.show"), post %></td>
         <td><%= link_to t("defaults.edit"), edit_post_path(post) %></td>
         <td><%= link_to t("defaults.destroy"), post, method: :delete, data: { confirm: t("defaults.message.delete_confirm") } %></td>

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -2,10 +2,21 @@
   <strong><%= Post.human_attribute_name(:id) %>:</strong>
   <%= @post.id %>
 </p>
-
+<p>
+  <strong><%= Post.human_attribute_name(:title) %>:</strong>
+  <%= @post.title %>
+</p>
 <p>
   <strong><%= Post.human_attribute_name(:body) %>:</strong>
   <%= @post.body %>
+</p>
+<p>
+  <strong><%= Post.human_attribute_name(:url) %>:</strong>
+  <%= @post.url %>
+</p>
+<p>
+  <strong><%= Post.human_attribute_name(:contributor) %>:</strong>
+  <%= @post.contributor %>
 </p>
 
 <%= link_to t("defaults.edit"), edit_post_path(@post) %> |

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -8,5 +8,8 @@ ja:
         email: "メールアドレス"
         password: "パスワード"
       post:
+        title: "タイトル"
         body: "本文"
+        url: "MattermostURL"
+        contributor: "投稿者"
 

--- a/db/migrate/20220423071852_rename_body_column_to_posts.rb
+++ b/db/migrate/20220423071852_rename_body_column_to_posts.rb
@@ -1,0 +1,5 @@
+class RenameBodyColumnToPosts < ActiveRecord::Migration[6.1]
+  def change
+    rename_column :posts, :body, :url
+  end
+end

--- a/db/migrate/20220424204939_add_uniq_index_to_url_from_posts.rb
+++ b/db/migrate/20220424204939_add_uniq_index_to_url_from_posts.rb
@@ -1,0 +1,5 @@
+class AddUniqIndexToUrlFromPosts < ActiveRecord::Migration[6.1]
+  def change
+    add_index :posts, :url, unique: true
+  end
+end

--- a/db/migrate/20220425052949_add_columns_to_posts.rb
+++ b/db/migrate/20220425052949_add_columns_to_posts.rb
@@ -1,0 +1,9 @@
+class AddColumnsToPosts < ActiveRecord::Migration[6.1]
+  def change
+    add_column :posts, :title, :string, null: false
+    add_column :posts, :body, :text, null: false
+    add_column :posts, :contributor, :string, null: false
+    add_index :posts, :title, unique: true
+    add_index :posts, :body, unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_24_204939) do
+ActiveRecord::Schema.define(version: 2022_04_25_052949) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -20,6 +20,11 @@ ActiveRecord::Schema.define(version: 2022_04_24_204939) do
     t.text "url", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "title", null: false
+    t.text "body", null: false
+    t.string "contributor", null: false
+    t.index ["body"], name: "index_posts_on_body", unique: true
+    t.index ["title"], name: "index_posts_on_title", unique: true
     t.index ["url"], name: "index_posts_on_url", unique: true
   end
 

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_23_071852) do
+ActiveRecord::Schema.define(version: 2022_04_24_204939) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2022_04_23_071852) do
     t.text "url", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.index ["url"], name: "index_posts_on_url", unique: true
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,14 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_12_073306) do
+ActiveRecord::Schema.define(version: 2022_04_23_071852) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
   enable_extension "plpgsql"
 
   create_table "posts", force: :cascade do |t|
-    t.text "body", null: false
+    t.text "url", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
   end

--- a/lib/tasks/task_mattermost.rake
+++ b/lib/tasks/task_mattermost.rake
@@ -7,8 +7,16 @@ namespace :task_mattermost do
     uri = URI.parse(ENV["MATTERMOST_INCOMING_WEBHOOKS_URL"])
     http = Net::HTTP.new(uri.host, uri.port)
     http.use_ssl = uri.scheme === "https"
+    posting_item = Post.random
 
-    params = { text: Post.random.body }
+    text =
+"### #{posting_item.title}
+#{posting_item.body}
+
+投稿URL: #{posting_item.url}
+投稿者: #{posting_item.contributor}"
+
+    params = { text: text  }
     headers = { "Content-Type" => "application/json" }
     response = http.post(uri.path, params.to_json, headers)
     puts response.code # status code


### PR DESCRIPTION
# Postテーブルに複数カラムを追加・Postingタスク変更

## 概要

### Postテーブルにカラム追加

変更前
* id
* body

変更後
* id
* title
* body
* url( 元bodyカラム )
* contributor

### Postingタスク(マタモ投稿タスク)をカラムの変更に合わせて改善

post.title
post.body
post.url
post.contributorの順番で一文にまとめて投稿されるようにしています。

## コメント

一旦カラムの追加とタスクの変更のみ対応しました。
たたき台として作ったので、こういうイメージじゃなかったなどあればコメントください！

## 本番環境に反映時の注意

本番環境に反映時、それぞれのカラムにnull: false制約をつけているので、rails db:migrateした際に既存のテーブルのレコードにnullが入るようになるのでエラーが出ると思います。一旦レコードをどこか別に保存して入力し直すなどの作業が発生すると思います。