### PR TITLE
#29 uniform posting frequency

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -1,5 +1,10 @@
 class Post < ApplicationRecord
   validates :body, presence: true
 
-  scope :random, -> { offset(rand(Post.count)).first }
+  scope :random_from_unposted, -> { where(submitted: false).order("RANDOM()").first }
+  scope :unsubmitted, -> { where(submitted: false) }
+
+  def submitted!
+    self.update(submitted: true)
+  end
 end

--- a/db/migrate/20220701064447_add_submitted_to_posts.rb
+++ b/db/migrate/20220701064447_add_submitted_to_posts.rb
@@ -1,0 +1,5 @@
+class AddSubmittedToPosts < ActiveRecord::Migration[6.1]
+  def change
+    add_column :posts, :submitted, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_04_12_073306) do
+ActiveRecord::Schema.define(version: 2022_07_01_064447) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "pgcrypto"
@@ -20,6 +20,7 @@ ActiveRecord::Schema.define(version: 2022_04_12_073306) do
     t.text "body", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "submitted", default: false, null: false
   end
 
   create_table "users", id: :uuid, default: -> { "gen_random_uuid()" }, force: :cascade do |t|


### PR DESCRIPTION
# 投稿の均一化

* Postテーブルにsubmittedカラムを追加
* task_mattermost:postingタスクでsubmitted: falseのもののみ投稿
* 全てsubmitted: trueになると全てfalseに変更
* もしスタートから全てsubmitted: trueだと例外を投げるのでその場合は例外処理で全てsubmitted: falseにアップデート

# 確認方法

* カラムを追加したので bundle exec rails db:migrate を実行してください
